### PR TITLE
Small fixes

### DIFF
--- a/classes/redhawk-device.bbclass
+++ b/classes/redhawk-device.bbclass
@@ -2,3 +2,4 @@
 
 inherit autotools-brokensep pkgconfig redhawk-entity
 
+DEPENDS += "omniorb-native omniorbpy-native"

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -105,7 +105,7 @@ DISTRO ?= "poky"
 #  - 'package_rpm' for rpm style packages
 # E.g.: PACKAGE_CLASSES ?= "package_rpm package_deb package_ipk"
 # We default to rpm:
-PACKAGE_CLASSES ?= "package_rpm"
+PACKAGE_CLASSES ?= "package_ipk"
 
 #
 # SDK target architecture


### PR DESCRIPTION
1. Patched out `package_rpm` in favor of `package_ipk`.  Building for RPMs results in a number of packaging errors about conflicting installations for python2.7, etc. from omniorb, omniorbpy, and other recipes outside of our layer.  Building for IPK has no such issue.  This warrants further investigation, but for now this fix is fine (in the past, we were building IPKs by default).
2. Patched the redhawk device BBCLASS to append `omniorb-native` and `omniorbpy-native` to the DEPENDS list since both are necessary if the recipe intends to run a node configuration script, for example (vs. install a start-up configuration script in `init.d` like the GPP does).