### PR TITLE
In the version of USRP_UHD this pulls down, the nodeconfig.py --inpla…

### DIFF
--- a/recipes-devices/usrp-uhd/usrp-uhd_5.0.0.bb
+++ b/recipes-devices/usrp-uhd/usrp-uhd_5.0.0.bb
@@ -80,6 +80,5 @@ do_install_append () {
         --usrptype="${RH_USRP_UHD_TYPE}" \
         --usrpip="${RH_USRP_UHD_IP}" \
         --usrpname="${RH_USRP_UHD_IP}" \
-        --usrpserial="${RH_USRP_UHD_SERIAL}" \
-        --inplace \
+        --usrpserial="${RH_USRP_UHD_SERIAL}"
 }


### PR DESCRIPTION
…ce option is actually --noinplace. So rather than passing --inplace, this will simply not pass --noinplace, which should have the same effect.