### PR TITLE
Minor updates related to building the RFNoC Programmable Persona

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ In the `contrib/scripts` folder is the `build-image.sh` script, a derivative of 
 
 To use it, link this script into your `build` directory, set it to executable, and specify the `BUILD_IMAGE` and `MACHINE` environment variables (e.g., `qemuarm` and `redhawk-gpp-image`).  Then running this script will go through the whole bitbake process for you, automated.
 
+SPD Patching
+------------
+
+The `scripts/spd_utility` has two purposes.  The first purpose is to take a `cpp` Component, SoftPkg, or Device that has a defined `x86_64` implementation and create a new implementation matching `cpp-REDHAWK_PROCESSOR`.  The output directory, etc. are all changed to match so that the output product will overwrite the original implementation back at the Domain controller, i.e., the second purpose.  The second purpose is to take the output product's SPD and merge it with the Domain's SDRROOT.  Together with collecting the ComponentHost package, the Domain will be able to distribute your assets in a multi-architecture Domain.  See `scripts/spd_utility --help` for arguments.
+
+ > NOTE: If you would like to disable this functionality for your package, include `NO_SPD_PATCH = "1"` in the recipe.
+
 Additional Resources
 --------------------
 

--- a/classes/redhawk-entity.bbclass
+++ b/classes/redhawk-entity.bbclass
@@ -39,9 +39,12 @@ do_configure_prepend () {
     export PATH="${OSSIEHOME_STAGED}/bin:${PATH}"
 }
 
+NO_SPD_PATCH ?= "0"
 do_spd_implementation_patch () {
-    export PYTHONPATH=${OSSIEHOME_STAGED_NATIVE}/lib/python:${PYTHONPATH}
-    spd_utility -n "${REDHAWK_PROCESSOR}" "${S}/.."
+    if [ ${NO_SPD_PATCH} -eq 0 ]; then
+        export PYTHONPATH=${OSSIEHOME_STAGED_NATIVE}/lib/python:${PYTHONPATH}
+        spd_utility -n "${REDHAWK_PROCESSOR}" "${S}/.."
+    fi
 }
 do_spd_implementation_patch[cleandirs] += "${S}/../cpp-${REDHAWK_PROCESSOR}"
 addtask spd_implementation_patch after do_compile before do_install

--- a/conf/versions/redhawk.inc
+++ b/conf/versions/redhawk.inc
@@ -5,5 +5,6 @@ require redhawk-${REDHAWK_VERSION}.inc
 # address that need using this variable, which can be overridden as needed.
 REDHAWK_PROCESSOR ?= "${HOST_ARCH}"
 REDHAWK_PROCESSOR_rpi ?= "armv7l"
+REDHAWK_PROCESSOR_ettus-e300 = "armv7l"
 REDHAWK_PROCESSOR_zynq ?= "armv7l"
 REDHAWK_PROCESSOR_zynqmp ?= "aarch64"

--- a/recipes-core/devices/rtl2832u_2.1.0.bb
+++ b/recipes-core/devices/rtl2832u_2.1.0.bb
@@ -64,6 +64,7 @@ do_link_nodeconfig () {
 
 # Install the template node
 do_install_append () {
+    export PYTHONPATH=${OSSIEHOME_STAGED_NATIVE}/lib/python:${PYTHONPATH}
     ${D}${SDRROOT}/dev/devices/rh/RTL2832U/nodeconfig.py \
         --sdrroot="${D}${SDRROOT}" \
         --nodename="DevMgr-${MACHINE}-RTL2832U" \

--- a/recipes-core/devices/usrp-uhd_6.1.0.bb
+++ b/recipes-core/devices/usrp-uhd_6.1.0.bb
@@ -68,6 +68,7 @@ do_link_nodeconfig () {
 
 # Install the template node
 do_install_append () {
+    export PYTHONPATH=${OSSIEHOME_STAGED_NATIVE}/lib/python:${PYTHONPATH}
     ${D}${SDRROOT}/dev/devices/rh/USRP_UHD/nodeconfig.py \
         --sdrroot="${D}${SDRROOT}" \
         --nodename="${RH_USRP_UHD_NODE_NAME}" \

--- a/recipes-deps/omniorb/omniorb/0004-LongDouble.patch
+++ b/recipes-deps/omniorb/omniorb/0004-LongDouble.patch
@@ -1,0 +1,77 @@
+Index: omniORB-4.2.3/include/omniORB4/CORBA_sysdep_auto.h
+===================================================================
+--- omniORB-4.2.3.orig/include/omniORB4/CORBA_sysdep_auto.h
++++ omniORB-4.2.3/include/omniORB4/CORBA_sysdep_auto.h
+@@ -68,12 +68,12 @@
+ 
+ #if !defined(OMNIORB_DISABLE_LONGDOUBLE)
+ #  if defined(SIZEOF_LONG_DOUBLE) && (SIZEOF_LONG_DOUBLE == 16)
+-#    define HAS_LongDouble
++// #    define HAS_LongDouble
+ #    define _CORBA_LONGDOUBLE_DECL long double
+ #  endif
+ 
+ #  if defined(SIZEOF_LONG_DOUBLE) && (SIZEOF_LONG_DOUBLE == 12) && defined(__i386__)
+-#    define HAS_LongDouble
++// #    define HAS_LongDouble
+ #    define _CORBA_LONGDOUBLE_DECL long double
+ #  endif
+ #endif
+Index: omniORB-4.2.3/include/omniORB4/CORBA_sysdep_trad.h
+===================================================================
+--- omniORB-4.2.3.orig/include/omniORB4/CORBA_sysdep_trad.h
++++ omniORB-4.2.3/include/omniORB4/CORBA_sysdep_trad.h
+@@ -134,7 +134,7 @@
+ 
+ // GCC claims to support long long on all platforms
+ #  define HAS_LongLong
+-#  define HAS_LongDouble
++// #  define HAS_LongDouble
+ #  define _CORBA_LONGLONG_DECL   long long
+ #  define _CORBA_ULONGLONG_DECL  unsigned long long
+ #  define _CORBA_LONGDOUBLE_DECL long double 
+@@ -188,7 +188,7 @@
+ #  define _CORBA_LONGDOUBLE_DECL long double 
+ #  define _CORBA_LONGLONG_CONST(x) (x##LL)
+ 
+-#  define HAS_LongDouble
++// #  define HAS_LongDouble
+ 
+ 
+ #elif defined(_MSC_VER)
+@@ -221,7 +221,7 @@
+ 
+ #  define HAVE_STRTOULL
+ 
+-#  define HAS_LongDouble
++// #  define HAS_LongDouble
+ #  define HAS_LongLong
+ #  define _CORBA_LONGDOUBLE_DECL long double
+ #  define _CORBA_LONGLONG_DECL   long long
+@@ -256,7 +256,7 @@
+ #    define HAS_Cplusplus_const_cast
+ #    define OMNI_REQUIRES_FQ_BASE_CTOR
+ #    define HAS_LongLong
+-#    define HAS_LongDouble
++// #    define HAS_LongDouble
+ #    define _CORBA_LONGLONG_DECL long long
+ #    define _CORBA_ULONGLONG_DECL unsigned long long
+ #    define _CORBA_LONGDOUBLE_DECL long double
+@@ -281,7 +281,7 @@
+ #    define HAS_Cplusplus_Namespace
+ #    define HAS_Std_Namespace
+ #    define HAS_LongLong
+-#    define HAS_LongDouble
++// #    define HAS_LongDouble
+ #    define _CORBA_LONGLONG_DECL long long
+ #    define _CORBA_ULONGLONG_DECL unsigned long long
+ #    define _CORBA_LONGDOUBLE_DECL long double
+@@ -301,7 +301,7 @@
+ #    define _CORBA_ULONGLONG_DECL  unsigned long long
+ #    define _CORBA_LONGLONG_CONST(x) (x##LL)
+ #    if defined(_FPWIDETYPES)
+-#      define HAS_LongDouble
++// #      define HAS_LongDouble
+ #      define _CORBA_LONGDOUBLE_DECL long double
+ #    endif
+ #    ifndef HAVE_STD

--- a/recipes-deps/omniorb/omniorb_4.2.3.bb
+++ b/recipes-deps/omniorb/omniorb_4.2.3.bb
@@ -42,7 +42,8 @@ SRC_URI_append = "\
     file://0001-beforeauto-cross.patch \
     file://0002-python-shebang.patch \
     file://0003-embedded-appl.patch \
-"
+    ${@'file://0004-LongDouble.patch' if d.getVar('SOC_FAMILY') == 'zynq' else ''} \
+    "
 
 S = "${WORKDIR}/omniORB-${PV}"
 


### PR DESCRIPTION
These bugs/issues were discovered and corrected when building the RFNoC Programmable Persona build (E310) internally.

 1. The E3xx does not have a REDHAWK_PROCESSOR predefined, so we've added it, given that it's a common target (ecc8ac5)
 2. ARM 32-bit builds need the LongDouble patch restored (0ed2930)
 3. The components, personas, and device were all pre-set to the correct CPU architecture so the SPD patching utility was unnecessary (also, that feature was not documented) (cc6e183)
 4. When building the USRP device, calling the node configuration script would fail since the native python path wasn't setup to use redhawk-native.  We've carried this to the RTL2832U device too (312fd09)