### PR TITLE
[rocko] RBDSDecoder ARM fix

### DIFF
--- a/recipes-core/components/rh-rbdsdecoder/arm-no-hard-float.configure.ac.patch
+++ b/recipes-core/components/rh-rbdsdecoder/arm-no-hard-float.configure.ac.patch
@@ -1,0 +1,13 @@
+Index: cpp/configure.ac
+===================================================================
+--- cpp.orig/configure.ac
++++ cpp/configure.ac
+@@ -43,7 +43,7 @@ AX_BOOST_REGEX
+ 
+ case $host_cpu in
+   *arm*)
+-             CPU_SPECIFIC_FLAGS='-mfpu=neon -ftree-vectorize -ffast-math -funsafe-math-optimizations -funsafe-loop-optimizations -ftree-loop-if-convert-stores -mfloat-abi=hard -ftree-vectorizer-verbose=1'
++             CPU_SPECIFIC_FLAGS='-ftree-vectorize -ffast-math -funsafe-math-optimizations -funsafe-loop-optimizations -ftree-loop-if-convert-stores -ftree-vectorizer-verbose=1'
+              BINDIR_SUFFIX='_arm'
+              ;;
+   *x86*)

--- a/recipes-core/components/rh-rbdsdecoder_2.0.1.bb
+++ b/recipes-core/components/rh-rbdsdecoder_2.0.1.bb
@@ -8,3 +8,7 @@ PR = "5"
 LIC_MD5 = "92aadbd9e4b26926809a4e97460613d5"
 
 require core-cpp-component.inc
+
+SRC_URI_append = "\
+    file://arm-no-hard-float.configure.ac.patch \
+"


### PR DESCRIPTION
Closes #40 

The configure.ac requires hard float even though there seems to
be no actual need for it at the implementation of this component.
By removing it via this patch, we can let Yocto apply those flags
if the target machine actually supports the feature(s).

Signed-off-by: Thomas Goodwin <btgoodwin@geontech.com>