### PR TITLE
[thud] Fixing redhawk-waveform.bbclass to parse and work correctly.

### DIFF
--- a/classes/redhawk-waveform.bbclass
+++ b/classes/redhawk-waveform.bbclass
@@ -4,13 +4,11 @@ inherit redhawk-sysroot
 FILES_${PN} += "${SDRROOT}/dom/waveforms/*"
 
 do_install () {
-  for path in $(find -name "*.sad.xml"); do
+  for path in $(find ${S} -name "*.sad.xml"); do
     wf_file_name=$(basename ${path})
     wf_name=${wf_file_name%.sad.xml}
 
     install -d ${D}${SDRROOT}/dom/waveforms/${wf_name}
-    install -m 0755 ${path} ${D}${SDRROOT}/dom/waveforms/${wf_name}/${wf_file_name}
+    install -m 0644 ${path} ${D}${SDRROOT}/dom/waveforms/${wf_name}/${wf_file_name}
   done
 }
-
-EXPORT_FUNCTIONS do_install


### PR DESCRIPTION
This addresses #48 by both finding the waveform SAD and then
installing it without being executable.

This addresses #45 by removing the EXPORT_FUNCTIONS use, which
fails to parse since the class name has hyphens in it.  Rather
than potentially break a lot of recipes by renaming all classes
to match the required change (redhawk_waveform.bbclass), we're
opting to not export the install task since as long as it works,
there really only is one way to install a waveform.

Signed-off-by: Thomas Goodwin <btgoodwin@geontech.com>