### PR TITLE
[rocko] Fix to patch all softpkg dependencies in the SPD

### DIFF
--- a/scripts/spd_utility
+++ b/scripts/spd_utility
@@ -111,8 +111,7 @@ def patch_source(spd_path, processor_name, replace=False):
             new_code.set_entrypoint(entrypoint)
     new_impl.set_processor([spd.processor(processor_name)])
     for dep in new_impl.get_dependency():
-        if dep.get_type() == 'runtime_requirements':
-            dep.get_softpkgref().get_implref().set_refid(new_impl_id)
+        dep.get_softpkgref().get_implref().set_refid(new_impl_id)
 
     _log.info('Finished Implementation: %s' % new_impl_id)
 


### PR DESCRIPTION
The attribute we're checking may not be important, and seems to
be set to 'other' in 2.2.3 vs. 'runtime_requirements' previously.
Since it's not important, we patch all softpkg dependencies now.

Signed-off-by: Thomas Goodwin <btgoodwin@geontech.com>